### PR TITLE
rename bad funcs instead of removing their samples

### DIFF
--- a/noinline_test.go
+++ b/noinline_test.go
@@ -14,6 +14,7 @@ func TestApplyNoInlineHack(t *testing.T) {
 	require.Equal(t, 17, leafSamples(prof, grpcProcessDataFunc))
 	require.NoError(t, ApplyNoInlineHack(prof))
 	require.Equal(t, 0, leafSamples(prof, grpcProcessDataFunc))
+	require.Equal(t, 17, leafSamples(prof, doNotInlinePrefix+grpcProcessDataFunc))
 }
 
 func loadTestProfile(t *testing.T, name string) *profile.Profile {


### PR DESCRIPTION
Removing the samples for functions that have known inlining issues skews the PGO profile and might cause previously cold functions to be promoted to hot functions.

It's probably not a big issue, but this is an easy improvement to make, so why not.

Kudos to Michael Pratt for pointing this out pointing this out in https://github.com/DataDog/datadog-pgo/pull/3#discussion_r1579652098