### PR TITLE
Improve error message and README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can learn more about this feature in our [official documentation](https://do
 3. Run `datadog-pgo` before your build step. E.g. for a service `foo` that runs in `prod` and has its main package in `./cmd/foo`, you should add this step:
 
 ```
-go run github.com/DataDog/datadog-pgo@latest 'service:foo env:prod' ./cmd/foo/default.pgo
+go run github.com/DataDog/datadog-pgo@latest "service:foo env:prod" ./cmd/foo/default.pgo
 ```
 
 That's it. The go toolchain will automatically pick up any `default.pgo` file in the main package, so there is no need to modify your `go build` step.

--- a/client.go
+++ b/client.go
@@ -165,7 +165,7 @@ func (c *Client) post(ctx context.Context, path string, payload any) ([]byte, er
 	}
 
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		return nil, fmt.Errorf("POST %s: %s: please check that your DD_API_KEY, DD_APP_KEY and DD_SITE env vars are set correctly", path, res.Status)
+		return nil, fmt.Errorf("%s: please check that your DD_API_KEY, DD_APP_KEY and DD_SITE env vars are set correctly and that your account has profiles matching your query", res.Status)
 	}
 	return resBody, nil
 }


### PR DESCRIPTION
* Remove the reference to failing endpoint. It's confusing and redundant (the `search and download profiles` part of the error message is sufficient to debug which endpoint is being hit)
* Improve the error hint to suggest checking that the account has the right data.
* Improve README example to use double quotes

**Before:**


> ERR search and download profiles: POST /api/unstable/profiles/gopgo: 404 Not Found: please check that your DD_API_KEY, DD_APP_KEY and DD_SITE env vars are set correctly and that your account has profiles matching your query

**After:**

> Jun 13 20:02:05.406 ERR search and download profiles: 404 Not Found: please check that your DD_API_KEY, DD_APP_KEY and DD_SITE env vars are set correctly and that your account has profiles matching your query

See JIRA for more information.