### PR TITLE
Temporarly remove runtime.gopark

### DIFF
--- a/noinline.go
+++ b/noinline.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	grpcProcessDataFunc = "google.golang.org/grpc/internal/transport.(*loopyWriter).processData"
+	runtimeGoparkFunc   = "runtime.gopark"
 	doNotInlinePrefix   = "DO NOT INLINE: "
 )
 
@@ -17,7 +18,7 @@ const (
 //
 // TODO: Delete this once it's fixed upstream.
 func ApplyNoInlineHack(prof *profile.Profile) error {
-	if err := renameNoInlineFuncs(prof, []string{grpcProcessDataFunc}); err != nil {
+	if err := renameNoInlineFuncs(prof, []string{grpcProcessDataFunc, runtimeGoparkFunc}); err != nil {
 		return fmt.Errorf("noinline hack: %w", err)
 	}
 	return nil


### PR DESCRIPTION
See https://github.com/golang/go/issues/74045. Basically, PGO can lead
to runtime.gopark getting inlined into runtime.ReadTrace. This leaves
runtime.ReadTrace without any voluntary preemption points when tracing
is shutting down. If the program tries to stop the world at that point,
the other goroutine consuming the trace will be stopped, and
runtime.ReadTrace will spin on parking waiting for that goroutine. Since
runtime.ReadTrace can't be asynchronously or synchronously preempted,
the whole program hangs.

The linked issue has fixes up. This commit is a coarse workaround: remove
runtime.gopark leaf frames so the function doesn't get inlined anywhere,
including runtime.ReadTrace.
